### PR TITLE
Fixed a bug in LM4F.ld

### DIFF
--- a/LM4F.ld
+++ b/LM4F.ld
@@ -24,18 +24,18 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
-* File:			LM4F.ld.
-* Author:		Mauro Scomparin <http://scompoprojects.worpress.com>.
-* Version:		1.0.0.
-* Description:	Linker description file for LM4FXXX microcontrollers.
+* File:     LM4F.ld.
+* Author:   Mauro Scomparin <http://scompoprojects.worpress.com>.
+* Version:    1.0.0.
+* Description:  Linker description file for LM4FXXX microcontrollers.
 */
 
 
 /*
 * Memory definition:
-* FLASH:	start point 0x00,		lenght 0x40000.
-* SRAM:		start point 0x20000000	length 0x8000.
-* STACK:	start point 0x20007FFF	lenght 0x0.
+* FLASH:  start point 0x00,   lenght 0x40000.
+* SRAM:   start point 0x20000000  length 0x8000.
+* STACK:  start point 0x20007FFF  lenght 0x0.
 */
 MEMORY
 {
@@ -47,25 +47,27 @@ MEMORY
 /*
 * Sections definitions:
 *
-* .text 		- machine instructions.
-* .data 		- initialized data defined in the program.
-* .bss  		- un-initialized global and static variables (to be initialized to 0 before starting main).
-* .stack		- just contains the pointer to the stack end at the right place.
+* .text     - machine instructions.
+* .data     - initialized data defined in the program.
+* .bss      - un-initialized global and static variables (to be initialized to 0 before starting main).
+* .stack    - just contains the pointer to the stack end at the right place.
 */
 SECTIONS
-{	
-	/* This section it's the code, containing the NVIC Vector table that must start at 0x0
-	*   Look at the LM4F120H5QR datasheet for details. (Table 2-8. Exception Types)
-	*/
+{ 
+  /* This section it's the code, containing the NVIC Vector table that must start at 0x0
+  *   Look at the LM4F120H5QR datasheet for details. (Table 2-8. Exception Types)
+  */
     .text : 
     {
-    	/*_start_text = .;	/* This is an index to the beginning of .text segment. */
-    	KEEP(*(.nvic_table)) /* I should keep the NVIC ISR Table because it's needed by the processor to start. */
-        *(.text.*)			/* This contains the code after the ISR table. */
-        *(.rodata.*)    	/* Read only data.  */
-        _end_text = .;		/* This is an index to the end of .text segment. */
+      /*_start_text = .;  /* This is an index to the beginning of .text segment. */
+      KEEP(*(.nvic_table)) /* I should keep the NVIC ISR Table because it's needed by the processor to start. */
+        *(.text.*)      /* This contains the code after the ISR table. */
+        *(.rodata*)      /* Read only data.  */
+        /*_end_text = .; */    /* This is an index to the end of .text segment. */
     }>FLASH
     
+    _end_text = ALIGN(8); 
+
     /* 
     * .data segment must be placed in RAM but it's originally stored in FLASH
     * So I set the data segment in ram, but I specify the load address with the AT
@@ -75,31 +77,35 @@ SECTIONS
     */
     .data : 
     {
-    	_start_data = .;	/* An index to the beginning of .data segment. */
-        *(vtable)			/* vtable should be the volatile data I guess*/
-        *(.data.*)			/* I should put there all my initialized data of my program. */
-        _end_data = .;		/* And another index to the end of .data segment. */
+      _start_data = .;  /* An index to the beginning of .data segment. */
+        *(vtable)     /* vtable should be the volatile data I guess*/
+        *(.data.*)      /* I should put there all my initialized data of my program. */
+        _end_data = .;    /* And another index to the end of .data segment. */
     }>RAM AT >FLASH
     
 
-	/* 
-	* .bss contains the unitialized variables and must be set as 0x0 during runtime.
-	* It should be loaded in RAM and particula care should be taken initializing them in the startup file. 
-	*/
+  /* 
+  * .bss contains the unitialized variables and must be set as 0x0 during runtime.
+  * It should be loaded in RAM and particula care should be taken initializing them in the startup file. 
+  */
     .bss : 
     {
-    	_start_bss = .;		/* This is an index to the beginning of .bss segment. */
-        *(.bss.*)       	/* The un-initialized data should go there.  */
-        *(COMMON)			/* All the other stuff should be put there */
-        _end_bss = .;		/* End index for .bss segment */
+      _start_bss = .;   /* This is an index to the beginning of .bss segment. */
+        *(.bss.*)         /* The un-initialized data should go there.  */
+        *(COMMON)     /* All the other stuff should be put there */
+        _end_bss = .;   /* End index for .bss segment */
     }>RAM
-    
-	/*
-	* .stack contains nothing, but I use it to set the first vector item (SP R13).
-	*/
-	.stack : 
-	{
-		_stack_top = .; /* An index to the end of the stack */
-	}>STACK
-	
+
+    PROVIDE( _HEAP_START = _end_bss);
+    PROVIDE( _HEAP_END = ALIGN(ORIGIN(RAM) + LENGTH(RAM) -8,8) );
+
+  /*
+  * .stack contains nothing, but I use it to set the first vector item (SP R13).
+  */
+  .stack : 
+  {
+    _stack_top = .; /* An index to the end of the stack */
+  }>STACK
+
+
 }

--- a/LM4F_startup.c
+++ b/LM4F_startup.c
@@ -24,14 +24,18 @@
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *
-* File:			LM4F_startup.c.
-* Author:		Mauro Scomparin <http://scompoprojects.worpress.com>.
-* Version:		1.0.0.
-* Description:	LM4F120H5QR startup code.
+* File:     LM4F_startup.c.
+* Author:   Mauro Scomparin <http://scompoprojects.worpress.com>.
+* Version:    1.0.0.
+* Description:  LM4F120H5QR startup code.
 */
 
+#include "inc/hw_nvic.h"
+#include "inc/hw_types.h"
+
+
 //-----------------------------------------------------------------------------
-// 							 Functions declarations
+//               Functions declarations
 //-----------------------------------------------------------------------------
 
 // Main should be defined on your main file so it's extern.
@@ -43,10 +47,10 @@ void nmi_handler(void);
 // this is just the default handler.
 void empty_def_handler(void);
 // this is the code for an hard fault.
-void hardfault_handler(void);
+void hardfault_handler(unsigned int * hardfault_args) ;
 
 //-----------------------------------------------------------------------------
-// 						     Variables declarations
+//                 Variables declarations
 //-----------------------------------------------------------------------------
 
 // defined by the linker it's the stack top variable (End of ram)
@@ -66,172 +70,172 @@ extern unsigned long _end_bss;
 // the funny looking void(* myvectors[])(void) basically it's a way to make cc accept an array of function pointers.
 __attribute__ ((section(".nvic_table")))
 void(* myvectors[])(void) = {
-	// This are the fixed priority interrupts and the stack pointer loaded at startup at R13 (SP).
-	//												VECTOR N (Check Datasheet)
-	// here the compiler it's boring.. have to figure that out
+  // This are the fixed priority interrupts and the stack pointer loaded at startup at R13 (SP).
+  //                        VECTOR N (Check Datasheet)
+  // here the compiler it's boring.. have to figure that out
     (void (*)) &_stack_top, 
-    						// stack pointer should be 
-							// placed here at startup.			0
-    rst_handler,			// code entry point					1
-    nmi_handler,			// NMI handler.						2
-    hardfault_handler,		// hard fault handler.				3
+                // stack pointer should be 
+              // placed here at startup.      0
+    rst_handler,      // code entry point         1
+    nmi_handler,      // NMI handler.           2
+    hardfault_handler,    // hard fault handler.        3
     // Configurable priority interruts handler start here.
-    empty_def_handler,		// Memory Management Fault			4
-    empty_def_handler,		// Bus Fault						5
-    empty_def_handler,		// Usage Fault 						6
-    0,						// Reserved							7
-    0,						// Reserved							8
-    0,						// Reserved							9
-    0,						// Reserved							10
-    empty_def_handler,		// SV call							11
-    empty_def_handler,		// Debug monitor					12
-    0,						// Reserved							13
-    empty_def_handler,		// PendSV							14
-    empty_def_handler,		// SysTick							15
+    empty_def_handler,    // Memory Management Fault      4
+    empty_def_handler,    // Bus Fault            5
+    empty_def_handler,    // Usage Fault            6
+    0,            // Reserved             7
+    0,            // Reserved             8
+    0,            // Reserved             9
+    0,            // Reserved             10
+    empty_def_handler,    // SV call              11
+    empty_def_handler,    // Debug monitor          12
+    0,            // Reserved             13
+    empty_def_handler,    // PendSV             14
+    empty_def_handler,    // SysTick              15
     // Peripherial interrupts start here.
-	empty_def_handler,		// GPIO Port A						16
-	empty_def_handler,		// GPIO Port B						17
-	empty_def_handler,		// GPIO Port C						18
-	empty_def_handler,		// GPIO Port D						19
-	empty_def_handler,		// GPIO Port E						20
-	empty_def_handler,		// UART 0							21
-	empty_def_handler,		// UART 1							22
-	empty_def_handler,		// SSI 0							23
-	empty_def_handler,		// I2C 0							24
-	0,						// Reserved							25
-	0,						// Reserved							26
-	0,						// Reserved							27
-	0,						// Reserved							28
-	0,						// Reserved							29
-	empty_def_handler,		// ADC 0 Seq 0						30
-	empty_def_handler,		// ADC 0 Seq 1						31
-	empty_def_handler,		// ADC 0 Seq 2						32
-	empty_def_handler,		// ADC 0 Seq 3						33
-	empty_def_handler,		// WDT 0 and 1						34
-	empty_def_handler,		// 16/32 bit timer 0 A				35
-	empty_def_handler,		// 16/32 bit timer 0 B				36
-	empty_def_handler,		// 16/32 bit timer 1 A				37
-	empty_def_handler,		// 16/32 bit timer 1 B				38
-	empty_def_handler,		// 16/32 bit timer 2 A				39
-	empty_def_handler,		// 16/32 bit timer 2 B				40
-	empty_def_handler,		// Analog comparator 0				41
-	empty_def_handler,		// Analog comparator 1				42
-	0,						// Reserved							43
-	empty_def_handler,		// System control					44
-	empty_def_handler,		// Flash + EEPROM control			45
-	empty_def_handler,		// GPIO Port F						46
-	0,						// Reserved							47
-	0,						// Reserved							48
-	empty_def_handler,		// UART 2							49
-	empty_def_handler,		// SSI 1							50
-	empty_def_handler,		// 16/32 bit timer 3 A				51
-	empty_def_handler,		// 16/32 bit timer 3 B				52
-	empty_def_handler,		// I2C 1							53
-	0,						// Reserved							54
-	empty_def_handler,		// CAN 0							55
-	0,						// Reserved							56
-	0,						// Reserved							57
-	0,						// Reserved							58
-	empty_def_handler,		// Hibernation module				59
-	empty_def_handler,		// USB								60
-	0,						// Reserved							61
-	empty_def_handler,		// UDMA SW							62
-	empty_def_handler,		// UDMA Error						63
-	empty_def_handler,		// ADC 1 Seq 0						64
-	empty_def_handler,		// ADC 1 Seq 1						65
-	empty_def_handler,		// ADC 1 Seq 2						66
-	empty_def_handler,		// ADC 1 Seq 3						67
-	0,						// Reserved							68
-	0,						// Reserved							69
-	0,						// Reserved							70
-	0,						// Reserved							71
-	0,						// Reserved							72
-	empty_def_handler,		// SSI 2							73
-	empty_def_handler,		// SSI 2							74
-	empty_def_handler,		// UART 3							75
-	empty_def_handler,		// UART 4							76
-	empty_def_handler,		// UART 5							77
-	empty_def_handler,		// UART 6							78
-	empty_def_handler,		// UART 7							79
-	0,						// Reserved							80
-	0,						// Reserved							81
-	0,						// Reserved							82
-	0,						// Reserved							83
-	empty_def_handler,		// I2C 2							84
-	empty_def_handler,		// I2C 4							85
-	empty_def_handler,		// 16/32 bit timer 4 A				86
-	empty_def_handler,		// 16/32 bit timer 4 B				87
-	0,						// Reserved							88
-	0,						// Reserved							89
-	0,						// Reserved							90
-	0,						// Reserved							91
-	0,						// Reserved							92
-	0,						// Reserved							93
-	0,						// Reserved							94
-	0,						// Reserved							95
-	0,						// Reserved							96
-	0,						// Reserved							97
-	0,						// Reserved							98
-	0,						// Reserved							99
-	0,						// Reserved							100
-	0,						// Reserved							101
-	0,						// Reserved							102
-	0,						// Reserved							103
-	0,						// Reserved							104
-	0,						// Reserved							105
-	0,						// Reserved							106
-	0,						// Reserved							107
-	empty_def_handler,		// 16/32 bit timer 5 A				108
-	empty_def_handler,		// 16/32 bit timer 5 B				109
-	empty_def_handler,		// 32/64 bit timer 0 A				110
-	empty_def_handler,		// 32/64 bit timer 0 B				111
-	empty_def_handler,		// 32/64 bit timer 1 A				112
-	empty_def_handler,		// 32/64 bit timer 1 B				113
-	empty_def_handler,		// 32/64 bit timer 2 A				114
-	empty_def_handler,		// 32/64 bit timer 2 B				115
-	empty_def_handler,		// 32/64 bit timer 3 A				116
-	empty_def_handler,		// 32/64 bit timer 3 B				117
-	empty_def_handler,		// 32/64 bit timer 4 A				118
-	empty_def_handler,		// 32/64 bit timer 4 B				119
-	empty_def_handler,		// 32/64 bit timer 5 A				120
-	empty_def_handler,		// 32/64 bit timer 5 B				121
-	empty_def_handler,		// System Exception					122
-	0,						// Reserved							123
-	0,						// Reserved							124
-	0,						// Reserved							125
-	0,						// Reserved							126
-	0,						// Reserved							127
-	0,						// Reserved							128
-	0,						// Reserved							129
-	0,						// Reserved							130
-	0,						// Reserved							131
-	0,						// Reserved							132
-	0,						// Reserved							133
-	0,						// Reserved							134
-	0,						// Reserved							135
-	0,						// Reserved							136
-	0,						// Reserved							137
-	0,						// Reserved							138
-	0,						// Reserved							139
-	0,						// Reserved							140
-	0,						// Reserved							141
-	0,						// Reserved							142
-	0,						// Reserved							143
-	0,						// Reserved							144
-	0,						// Reserved							145
-	0,						// Reserved							146
-	0,						// Reserved							147
-	0,						// Reserved							148
-	0,						// Reserved							149
-	0,						// Reserved							150
-	0,						// Reserved							151
-	0,						// Reserved							152
-	0,						// Reserved							153
-	0						// Reserved							154
+  empty_def_handler,    // GPIO Port A            16
+  empty_def_handler,    // GPIO Port B            17
+  empty_def_handler,    // GPIO Port C            18
+  empty_def_handler,    // GPIO Port D            19
+  empty_def_handler,    // GPIO Port E            20
+  empty_def_handler,    // UART 0             21
+  empty_def_handler,    // UART 1             22
+  empty_def_handler,    // SSI 0              23
+  empty_def_handler,    // I2C 0              24
+  0,            // Reserved             25
+  0,            // Reserved             26
+  0,            // Reserved             27
+  0,            // Reserved             28
+  0,            // Reserved             29
+  empty_def_handler,    // ADC 0 Seq 0            30
+  empty_def_handler,    // ADC 0 Seq 1            31
+  empty_def_handler,    // ADC 0 Seq 2            32
+  empty_def_handler,    // ADC 0 Seq 3            33
+  empty_def_handler,    // WDT 0 and 1            34
+  empty_def_handler,    // 16/32 bit timer 0 A        35
+  empty_def_handler,    // 16/32 bit timer 0 B        36
+  empty_def_handler,    // 16/32 bit timer 1 A        37
+  empty_def_handler,    // 16/32 bit timer 1 B        38
+  empty_def_handler,    // 16/32 bit timer 2 A        39
+  empty_def_handler,    // 16/32 bit timer 2 B        40
+  empty_def_handler,    // Analog comparator 0        41
+  empty_def_handler,    // Analog comparator 1        42
+  0,            // Reserved             43
+  empty_def_handler,    // System control         44
+  empty_def_handler,    // Flash + EEPROM control     45
+  empty_def_handler,    // GPIO Port F            46
+  0,            // Reserved             47
+  0,            // Reserved             48
+  empty_def_handler,    // UART 2             49
+  empty_def_handler,    // SSI 1              50
+  empty_def_handler,    // 16/32 bit timer 3 A        51
+  empty_def_handler,    // 16/32 bit timer 3 B        52
+  empty_def_handler,    // I2C 1              53
+  0,            // Reserved             54
+  empty_def_handler,    // CAN 0              55
+  0,            // Reserved             56
+  0,            // Reserved             57
+  0,            // Reserved             58
+  empty_def_handler,    // Hibernation module       59
+  empty_def_handler,    // USB                60
+  0,            // Reserved             61
+  empty_def_handler,    // UDMA SW              62
+  empty_def_handler,    // UDMA Error           63
+  empty_def_handler,    // ADC 1 Seq 0            64
+  empty_def_handler,    // ADC 1 Seq 1            65
+  empty_def_handler,    // ADC 1 Seq 2            66
+  empty_def_handler,    // ADC 1 Seq 3            67
+  0,            // Reserved             68
+  0,            // Reserved             69
+  0,            // Reserved             70
+  0,            // Reserved             71
+  0,            // Reserved             72
+  empty_def_handler,    // SSI 2              73
+  empty_def_handler,    // SSI 2              74
+  empty_def_handler,    // UART 3             75
+  empty_def_handler,    // UART 4             76
+  empty_def_handler,    // UART 5             77
+  empty_def_handler,    // UART 6             78
+  empty_def_handler,    // UART 7             79
+  0,            // Reserved             80
+  0,            // Reserved             81
+  0,            // Reserved             82
+  0,            // Reserved             83
+  empty_def_handler,    // I2C 2              84
+  empty_def_handler,    // I2C 4              85
+  empty_def_handler,    // 16/32 bit timer 4 A        86
+  empty_def_handler,    // 16/32 bit timer 4 B        87
+  0,            // Reserved             88
+  0,            // Reserved             89
+  0,            // Reserved             90
+  0,            // Reserved             91
+  0,            // Reserved             92
+  0,            // Reserved             93
+  0,            // Reserved             94
+  0,            // Reserved             95
+  0,            // Reserved             96
+  0,            // Reserved             97
+  0,            // Reserved             98
+  0,            // Reserved             99
+  0,            // Reserved             100
+  0,            // Reserved             101
+  0,            // Reserved             102
+  0,            // Reserved             103
+  0,            // Reserved             104
+  0,            // Reserved             105
+  0,            // Reserved             106
+  0,            // Reserved             107
+  empty_def_handler,    // 16/32 bit timer 5 A        108
+  empty_def_handler,    // 16/32 bit timer 5 B        109
+  empty_def_handler,    // 32/64 bit timer 0 A        110
+  empty_def_handler,    // 32/64 bit timer 0 B        111
+  empty_def_handler,    // 32/64 bit timer 1 A        112
+  empty_def_handler,    // 32/64 bit timer 1 B        113
+  empty_def_handler,    // 32/64 bit timer 2 A        114
+  empty_def_handler,    // 32/64 bit timer 2 B        115
+  empty_def_handler,    // 32/64 bit timer 3 A        116
+  empty_def_handler,    // 32/64 bit timer 3 B        117
+  empty_def_handler,    // 32/64 bit timer 4 A        118
+  empty_def_handler,    // 32/64 bit timer 4 B        119
+  empty_def_handler,    // 32/64 bit timer 5 A        120
+  empty_def_handler,    // 32/64 bit timer 5 B        121
+  empty_def_handler,    // System Exception         122
+  0,            // Reserved             123
+  0,            // Reserved             124
+  0,            // Reserved             125
+  0,            // Reserved             126
+  0,            // Reserved             127
+  0,            // Reserved             128
+  0,            // Reserved             129
+  0,            // Reserved             130
+  0,            // Reserved             131
+  0,            // Reserved             132
+  0,            // Reserved             133
+  0,            // Reserved             134
+  0,            // Reserved             135
+  0,            // Reserved             136
+  0,            // Reserved             137
+  0,            // Reserved             138
+  0,            // Reserved             139
+  0,            // Reserved             140
+  0,            // Reserved             141
+  0,            // Reserved             142
+  0,            // Reserved             143
+  0,            // Reserved             144
+  0,            // Reserved             145
+  0,            // Reserved             146
+  0,            // Reserved             147
+  0,            // Reserved             148
+  0,            // Reserved             149
+  0,            // Reserved             150
+  0,            // Reserved             151
+  0,            // Reserved             152
+  0,            // Reserved             153
+  0           // Reserved             154
 };
 
 //-----------------------------------------------------------------------------
-// 							Function implementations.
+//              Function implementations.
 //-----------------------------------------------------------------------------
 
 /* 
@@ -241,54 +245,105 @@ void(* myvectors[])(void) = {
 * Copy the .data segment from flash into ram.
 * 0 to the .bss segment 
 */
-	
-void rst_handler(void){	
-	// Copy the .data section pointers to ram from flash.
-	// Look at LD manual (Optional Section Attributes).
-	
-	// source and destination pointers
-	unsigned long *src;
-	unsigned long *dest;
-	
-	//this should be good!
-	src = &_end_text;
-	dest = &_start_data;
-	
-	//this too
+
+void rst_handler(void){ 
+  // Copy the .data section pointers to ram from flash.
+  // Look at LD manual (Optional Section Attributes).
+
+  // source and destination pointers
+  unsigned long *src;
+  unsigned long *dest;
+
+  //this should be good!
+  src = &_end_text;
+  dest = &_start_data;
+
+  //this too
     while(dest < &_end_data)
     {
         *dest++ = *src++;
     }
-	
+
     // now set the .bss segment to 0!
     dest = &_start_bss;
-	while(dest < &_end_bss){
-		*dest++ = 0;
-	}
-	
-	// after setting copying .data to ram and "zero-ing" .bss we are good
-	// to start the main() method!
-	// There you go!
-	main();
+  while(dest < &_end_bss){
+    *dest++ = 0;
+  }
+
+    //  
+    // Enable the floating-point unit.  This must be done here to handle the
+    // case where main() uses floating-point and the function prologue saves
+    // floating-point registers (which will fault if floating-point is not
+    // enabled).  Any configuration of the floating-point unit using DriverLib
+    // APIs must be done here prior to the floating-point unit being enabled.
+    //  
+    // Note that this does not use DriverLib since it might not be included in
+    // this project.
+    //  
+    HWREG(NVIC_CPAC) = ((HWREG(NVIC_CPAC) &
+                         ~(NVIC_CPAC_CP10_M | NVIC_CPAC_CP11_M)) |
+                        NVIC_CPAC_CP10_FULL | NVIC_CPAC_CP11_FULL);
+
+
+  // after setting copying .data to ram and "zero-ing" .bss we are good
+  // to start the main() method!
+  // There you go!
+  main();
 }
 
 // NMI Exception handler code NVIC 2
 void nmi_handler(void){
-	// Just loop forever, so if you want to debug the processor it's running.
+  UARTprintf("NMI Exception\n");
+  // Just loop forever, so if you want to debug the processor it's running.
     while(1){
     }
 }
 
 // Hard fault handler code NVIC 3
-void hardfault_handler(void){
-	// Just loop forever, so if you want to debug the processor it's running.
-    while(1){
-    }
+void hardfault_handler( unsigned int * hardfault_args ){
+
+
+  // Just loop forever, so if you want to debug the processor it's running.
+ unsigned int stacked_r0;
+  unsigned int stacked_r1;
+  unsigned int stacked_r2;
+  unsigned int stacked_r3;
+  unsigned int stacked_r12;
+  unsigned int stacked_lr;
+  unsigned int stacked_pc;
+  unsigned int stacked_psr;
+ 
+  stacked_r0 = ((unsigned long) hardfault_args[0]);
+  stacked_r1 = ((unsigned long) hardfault_args[1]);
+  stacked_r2 = ((unsigned long) hardfault_args[2]);
+  stacked_r3 = ((unsigned long) hardfault_args[3]);
+ 
+  stacked_r12 = ((unsigned long) hardfault_args[4]);
+  stacked_lr = ((unsigned long) hardfault_args[5]);
+  stacked_pc = ((unsigned long) hardfault_args[6]);
+  stacked_psr = ((unsigned long) hardfault_args[7]);
+ 
+  UARTprintf ("\n\n[Hard fault handler - all numbers in hex]\n");
+  UARTprintf ("R0 = %x\n", stacked_r0);
+  UARTprintf ("R1 = %x\n", stacked_r1);
+  UARTprintf ("R2 = %x\n", stacked_r2);
+  UARTprintf ("R3 = %x\n", stacked_r3);
+  UARTprintf ("R12 = %x\n", stacked_r12);
+  UARTprintf ("LR [R14] = %x  subroutine call return address\n", stacked_lr);
+  UARTprintf ("PC [R15] = %x  program counter\n", stacked_pc);
+  UARTprintf ("PSR = %x\n", stacked_psr);
+  UARTprintf ("BFAR = %x\n", (*((volatile unsigned long *)(0xE000ED38))));
+  UARTprintf ("CFSR = %x\n", (*((volatile unsigned long *)(0xE000ED28))));
+  UARTprintf ("HFSR = %x\n", (*((volatile unsigned long *)(0xE000ED2C))));
+  UARTprintf ("DFSR = %x\n", (*((volatile unsigned long *)(0xE000ED30))));
+  UARTprintf ("AFSR = %x\n", (*((volatile unsigned long *)(0xE000ED3C))));
+  while (1) { }; 
 }
 
 // Empty handler used as default.
 void empty_def_handler(void){
-	// Just loop forever, so if you want to debug the processor it's running.
+  // Just loop forever, so if you want to debug the processor it's running.
+    UARTprintf("UNKNOWN Exception\n");
     while(1){
     }
 }

--- a/newlib_stubs.c
+++ b/newlib_stubs.c
@@ -1,0 +1,268 @@
+/*
+ * newlib_stubs.c
+ *
+ *  Created on: 2 Nov 2010
+ *      Author: nanoage.co.uk
+ */
+#include "inc/hw_gpio.h"
+#include "inc/hw_types.h"
+#include "inc/hw_memmap.h"
+#include "inc/hw_ints.h"
+#include "inc/hw_sysctl.h"
+
+#include <stdint.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/times.h>
+#include <sys/unistd.h>
+#include "driverlib/uart.h"
+
+#ifndef STDOUT_USART
+#define STDOUT_USART 1
+#endif
+
+#ifndef STDERR_USART
+#define STDERR_USART 1
+#endif
+
+#ifndef STDIN_USART
+#define STDIN_USART 1
+#endif
+
+#undef errno
+extern int errno;
+
+extern unsigned int _HEAP_START;
+extern unsigned int _HEAP_END;
+static caddr_t heap = NULL ;
+
+/*
+ environ
+ A pointer to a list of environment variables and their values. 
+ For a minimal environment, this empty list is adequate:
+ */
+char *__env[1] = { 0 };
+char **environ = __env;
+
+
+
+void _exit(int status) {
+    _write(1, "exit", 4);
+    while (1) {
+        ;
+    }
+}
+
+int _close(int file) {
+    return -1;
+}
+/*
+ execve
+ Transfer control to a new process. Minimal implementation (for a system without processes):
+ */
+int _execve(char *name, char **argv, char **env) {
+    errno = ENOMEM;
+    return -1;
+}
+/*
+ fork
+ Create a new process. Minimal implementation (for a system without processes):
+ */
+
+int _fork() {
+    errno = EAGAIN;
+    return -1;
+}
+/*
+ fstat
+ Status of an open file. For consistency with other minimal implementations in these examples,
+ all files are regarded as character special devices.
+ The `sys/stat.h' header file required is distributed in the `include' subdirectory for this C library.
+ */
+int _fstat(int file, struct stat *st) {
+    UARTprintf("_fstat\n");
+    st->st_mode = S_IFCHR;
+    return 0;
+}
+
+/*
+ getpid
+ Process-ID; this is sometimes used to generate strings unlikely to conflict with other processes. Minimal implementation, for a system without processes:
+ */
+
+int _getpid() {
+    return 1;
+}
+
+/*
+ isatty
+ Query whether output stream is a terminal. For consistency with the other minimal implementations,
+ */
+int _isatty(int file) {
+    UARTprintf("_isatty\n");
+    switch (file){
+    case STDOUT_FILENO:
+    case STDERR_FILENO:
+    case STDIN_FILENO:
+        return 1;
+    default:
+        //errno = ENOTTY;
+        errno = EBADF;
+        return 0;
+    }
+}
+
+
+/*
+ kill
+ Send a signal. Minimal implementation:
+ */
+int _kill(int pid, int sig) {
+    errno = EINVAL;
+    return (-1);
+}
+
+/*
+ link
+ Establish a new name for an existing file. Minimal implementation:
+ */
+
+int _link(char *old, char *new) {
+    errno = EMLINK;
+    return -1;
+}
+
+/*
+ lseek
+ Set position in a file. Minimal implementation:
+ */
+int _lseek(int file, int ptr, int dir) {
+    return 0;
+}
+
+
+
+/*
+ sbrk
+ Increase program data space.
+ Malloc and related functions depend on this
+ */
+caddr_t _sbrk(int increment) {
+  UARTprintf("_sbrk");
+
+  caddr_t prevHeap, nextHeap;
+
+  if (heap == NULL)
+  {
+    heap = (caddr_t)&_HEAP_START;
+  }
+
+  prevHeap = heap;
+  nextHeap = (caddr_t)(((unsigned int)(heap + increment) + 7) & ~7);
+  register caddr_t stackPtr __asm ("sp");
+
+  if ( (nextHeap > stackPtr) || 
+      (nextHeap >= (caddr_t)&_HEAP_END))
+  {
+    return NULL; // error - no more memory
+  } else
+  {
+    heap = nextHeap;
+    return (caddr_t) prevHeap;
+  }
+
+}
+
+/*
+ read
+ Read a character to a file. `libc' subroutines will use this system routine for input from all files, including stdin
+ Returns -1 on error or blocks until the number of characters have been read.
+ */
+
+
+int _read(int file, char *ptr, int len) {
+    int n;
+    int num = 0;
+    char c;
+    UARTprintf("_read");
+
+    switch (file) {
+    case STDIN_FILENO:
+        for (n = 0; n < len; n++) {
+            do 
+            {
+              c = UARTCharGetNonBlocking(UART0_BASE);
+            } while (c == -1);
+
+            *ptr++ = c;
+            num++;
+        }
+        break;
+    default:
+        errno = EBADF;
+        return -1;
+    }
+    return num;
+}
+
+/*
+ stat
+ Status of a file (by name). Minimal implementation:
+ int    _EXFUN(stat,( const char *__path, struct stat *__sbuf ));
+ */
+
+int _stat(const char *filepath, struct stat *st) {
+    st->st_mode = S_IFCHR;
+    return 0;
+}
+
+/*
+ times
+ Timing information for current process. Minimal implementation:
+ */
+
+clock_t _times(struct tms *buf) {
+    return -1;
+}
+
+/*
+ unlink
+ Remove a file's directory entry. Minimal implementation:
+ */
+int _unlink(char *name) {
+    errno = ENOENT;
+    return -1;
+}
+
+/*
+ wait
+ Wait for a child process. Minimal implementation:
+ */
+int _wait(int *status) {
+    errno = ECHILD;
+    return -1;
+}
+
+/*
+ write
+ Write a character to a file. `libc' subroutines will use this system routine for output to all files, including stdout
+ Returns -1 on error or number of bytes sent
+ */
+int _write(int file, char *ptr, int len) {
+    int n;
+
+    UARTprintf("_write\n");
+
+    switch (file) {
+    case STDOUT_FILENO: /*stdout*/
+    case STDERR_FILENO:
+        for (n = 0; n < len; n++) {
+          UARTCharPut(UART0_BASE, ptr[n]);
+        }
+        break;
+    default:
+        errno = EBADF;
+        return -1;
+    }
+    return len;
+}


### PR DESCRIPTION
The main difference is in LM4F.ld   where _end_text is defined, it did not include .rodata for whatever reason.   This caused a hard fault when many libc functions were called in my code.   

After some advice, the updated LM4F.ld seems to account for .rodata and the data gets copied correctly.    Also, in the template is an implementation of newlib stubs.     Using these changes, I can now use printf() and malloc() provided by newlib from the template.

Also, great work with lm4tools.   To figure out this problem I used the new ICDI in openocd which seems to work great! 

[edit]  you can probably ignore this..  your LD script ended up still breaking in other ways so I replaced it alltogether.  It was doing weird things with the  text and data sections.    I'll update my template later with the new ld script and modified startup/syscalls 

Cheers.
Mark Roy
